### PR TITLE
Extend reading the --use remote images-- config variables from .env

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -183,3 +183,13 @@ foreach ( $required_constants as $constant ) {
 		die( "Please define: $constant in your .env file" ); // phpcs:ignore
 	}
 }
+
+/**
+ * Allow serving images from remote location
+ * using dekode-remote-images.php mu-plugin
+ *
+ * Used in development environment
+ */
+define( 'DEKODE_PREPEND_IMAGE_URL', env( 'DEKODE_PREPEND_IMAGE_URL' ) );
+define( 'DRI_CONTENT_FOLDER_NAME', env( 'DRI_CONTENT_FOLDER_NAME' ) );
+


### PR DESCRIPTION
We are using the dekode-remote-images.php muplugin to fetch the remote images using this configuration in the .env file:

` DEKODE_PREPEND_IMAGE_URL=https://current-project.dev05.dekodes.no/ `
` DRI_CONTENT_FOLDER_NAME='content' `

But these environment settings are not read by the application.php
