### PR TITLE
Add create-block scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
 		"webpack-remove-empty-scripts": "~0.7.1"
 	},
 	"scripts": {
+		"create-block": "cd packages/plugins && npx dekodeinteraktiv/create-project-base-block",
+		"create-innerblock-block": "cd packages/plugins && npx dekodeinteraktiv/create-project-base-block --template innerblocks",
 		"prepare": "husky install",
 		"start": "wp-scripts start",
 		"build": "wp-scripts build",


### PR DESCRIPTION
# Create Block-scripts

Two new npm scripts for easier bootstrapping of blocks, inspired by Gutenbergs create-block. One for innerblocks, the other for plain blocks.

Generates all the necessary files needed in the `/packages/plugins`-dir to get going.

Made using mustache templates, that populate everything from the php namespace, to the css-classes.

## Package repo

https://github.com/DekodeInteraktiv/create-project-base-block