### PR TITLE
Place assets to subfolders in build folder

### DIFF
--- a/packages/themes/dekode-theme/entry-files.json
+++ b/packages/themes/dekode-theme/entry-files.json
@@ -1,1 +1,1 @@
-["index.js", "style.css"]
+["index.js", "style.css", "hero/index.js"]

--- a/packages/themes/dekode-theme/src/hero/index.js
+++ b/packages/themes/dekode-theme/src/hero/index.js
@@ -1,0 +1,1 @@
+console.log('hero/index.js example'); // eslint-disable-line no-console

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,9 +89,9 @@ function getEntryFiles() {
 const prepareConfig = (dir, files) => {
 	const entries = {};
 
-	files.forEach( ( file ) => {
-		const filePath = path.resolve( __dirname, dir, file );
-		const pathParts = path.parse( file );
+	files.forEach((file) => {
+		const filePath = path.resolve(__dirname, dir, file);
+		const pathParts = path.parse(file);
 		const fileName = pathParts.name;
 		let subDirectory = pathParts.dir;
 
@@ -101,18 +101,18 @@ const prepareConfig = (dir, files) => {
 		 * All assets of hero/index.js should be places to build/hero/
 		 */
 		subDirectory = subDirectory
-			.split( '/' )
-			.filter( ( folder, i ) => ! ( folder === 'src' && i === 0 ) )
-			.join( '/' );
+			.split('/')
+			.filter((folder, i) => !(folder === 'src' && i === 0))
+			.join('/');
 
-		const entryKey = ( subDirectory ? subDirectory + '/' : '' ) + fileName;
+		const entryKey = (subDirectory ? subDirectory + '/' : '') + fileName;
 
-		if ( typeof entries[ entryKey ] === 'undefined' ) {
-			entries[ entryKey ] = [];
+		if (typeof entries[entryKey] === 'undefined') {
+			entries[entryKey] = [];
 		}
 
-		entries[ entryKey ].push( filePath );
-	} );
+		entries[entryKey].push(filePath);
+	});
 
 	const config = {
 		...defaultConfig,


### PR DESCRIPTION
If the entry file has items with subfolders, place them to subfolders in the build folder.
It had incorrect behaviour. Webpack has been joining all content to a single file for files with the same base name.

`["index.js", "hero/index.js", "style.css"]`

the result:

* build
    * index.js
    * hero
        * index.js
    * style.css  