### PR TITLE
Use generated WP_HOME by default, include fixes added to NB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,7 @@
 #MYSQLI_DEFAULT_SOCKET=/var/run/mysqld/mysqld.sock # optional
 
 ### Home & URL
-WP_HOME=http://site.local
-WP_SITEURL=${WP_HOME}/wp
+#WP_HOME=http://site.local
 
 ### Network Setup
 #WP_ALLOW_MULTISITE=false


### PR DESCRIPTION
1. Include changes from the two NB commits https://github.com/DekodeInteraktiv/nasjonalbiblioteket/commit/06a66702f908a461d61c09a456f6341a6299c48d https://github.com/DekodeInteraktiv/nasjonalbiblioteket/commit/4ce08c29cbcc53d3d58307ab3a0975cde54813e3
1. Flatten if/else for setting `WP_HOME` to `env()` fallback parameter.
1. Always set `WP_SITEURL` to `{WP_HOME}/wp`
1. Use generated `WP_HOME` by default. Commented out env var.
