### PR TITLE
Add postcss extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"postcss-media-minmax": "^5.0.0",
 		"postcss-mixins": "^9.0.3",
 		"postcss-nesting": "^10.1.8",
+		"postcss-mixins": "^9.0.3",
 		"prettier": "^2.7.1",
 		"resolve-url-loader": "^5.0.0",
 		"webpack-remove-empty-scripts": "^0.8.1"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,6 +8,7 @@ const customMedia = require('postcss-custom-media');
 const minmax = require('postcss-media-minmax');
 const mixins = require('postcss-mixins');
 const postcssNesting = require('postcss-nesting');
+const postcssExtend = require('postcss-extend');
 const postcssFlexbugsFixes = require('postcss-flexbugs-fixes');
 
 module.exports = (ctx) => {
@@ -16,6 +17,7 @@ module.exports = (ctx) => {
 			atImport(),
 			mixins,
 			postcssFlexbugsFixes,
+			postcssExtend,
 			postcssNesting,
 			customMedia(),
 			minmax(),


### PR DESCRIPTION
Adds extend compiling to postcss. This lets us reuse CSS and do things like bundle font-size and line-height

example:

```
%caption {
  font-size: var(--font-size-s);
  text-transform: uppercase;
  letter-spacing: 0.01em;
}

label {
 @extend %caption;
}

.featured-content-label{
  @extend %caption;
  font-size: var(--font-size-m);
}

```