### PR TITLE
Update dependencies for WordPress, T2, and dev tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
 		"dekode/block-theme": "~1.0.0",
 		"inpsyde/wp-translation-downloader": "~2.6.0",
 		"roots/bedrock-autoloader": "~1.0.4",
-		"roots/wordpress": "~6.8.2",
+		"roots/wordpress": "~6.8.3",
 		"symfony/dotenv": "~7.3.2",
-		"t2/t2": "~8.18.1",
+		"t2/t2": "~8.19.0",
 		"wpackagist-plugin/imagify": "~2.2.0",
-		"wpackagist-plugin/spinupwp": "~1.8.0",
+		"wpackagist-plugin/spinupwp": "~1.9.0",
 		"wpackagist-plugin/two-factor": "~0.14.0"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a2b971296fc8383a7d493ad77823c17",
+    "content-hash": "6678cb10c3075b320fb91011ea3400de",
     "packages": [
         {
             "name": "composer/installers",
@@ -321,7 +321,7 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "6.8.2",
+            "version": "6.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress.git",
@@ -352,7 +352,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/6.8.2"
+                "source": "https://github.com/roots/wordpress/tree/6.8.3"
             },
             "funding": [
                 {
@@ -431,23 +431,23 @@
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "6.8.2",
+            "version": "6.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.8.2"
+                "reference": "6.8.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/release/wordpress-6.8.2-no-content.zip",
-                "reference": "6.8.2",
-                "shasum": "7d8dcb839f4754e331d93b86f9adc8c171d81e97"
+                "url": "https://downloads.wordpress.org/release/wordpress-6.8.3-no-content.zip",
+                "reference": "6.8.3",
+                "shasum": "2c34ba506afd8061d96cde50b2c92f109c10d2c8"
             },
             "require": {
                 "php": ">= 7.2.24"
             },
             "provide": {
-                "wordpress/core-implementation": "6.8.2"
+                "wordpress/core-implementation": "6.8.3"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -498,7 +498,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2025-07-15T15:29:08+00:00"
+            "time": "2025-09-30T18:16:31+00:00"
         },
         {
             "name": "symfony/dotenv",
@@ -580,15 +580,15 @@
         },
         {
             "name": "t2/admin",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-admin-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-admin-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.18.1",
-                "t2/icons": "8.18.1"
+                "t2/config": "8.19.0",
+                "t2/icons": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -609,10 +609,10 @@
         },
         {
             "name": "t2/assets",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-assets-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-assets-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -636,17 +636,17 @@
         },
         {
             "name": "t2/block-library",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-block-library-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-block-library-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/blocks": "8.18.1",
-                "t2/config": "8.18.1",
-                "t2/icons": "8.18.1",
-                "t2/utils": "8.18.1"
+                "t2/blocks": "8.19.0",
+                "t2/config": "8.19.0",
+                "t2/icons": "8.19.0",
+                "t2/utils": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -667,16 +667,16 @@
         },
         {
             "name": "t2/blocks",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-blocks-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-blocks-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.18.1",
-                "t2/registry": "8.18.1",
-                "t2/utils": "8.18.1"
+                "t2/config": "8.19.0",
+                "t2/registry": "8.19.0",
+                "t2/utils": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -698,10 +698,10 @@
         },
         {
             "name": "t2/config",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-config-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-config-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -725,16 +725,16 @@
         },
         {
             "name": "t2/editor",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-editor-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-editor-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.18.1",
-                "t2/icons": "8.18.1",
-                "t2/utils": "8.18.1"
+                "t2/config": "8.19.0",
+                "t2/icons": "8.19.0",
+                "t2/utils": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -755,17 +755,17 @@
         },
         {
             "name": "t2/extension-library",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extension-library-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.18.1",
-                "t2/extensions": "8.18.1",
-                "t2/icons": "8.18.1",
-                "t2/utils": "8.18.1"
+                "t2/config": "8.19.0",
+                "t2/extensions": "8.19.0",
+                "t2/icons": "8.19.0",
+                "t2/utils": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -786,16 +786,16 @@
         },
         {
             "name": "t2/extensions",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-extensions-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-extensions-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/config": "8.18.1",
-                "t2/registry": "8.18.1",
-                "t2/utils": "8.18.1"
+                "t2/config": "8.19.0",
+                "t2/registry": "8.19.0",
+                "t2/utils": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -816,14 +816,14 @@
         },
         {
             "name": "t2/icons",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-icons-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-icons-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/utils": "8.18.1"
+                "t2/utils": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -844,10 +844,10 @@
         },
         {
             "name": "t2/registry",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-registry-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-registry-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2"
@@ -872,23 +872,23 @@
         },
         {
             "name": "t2/t2",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-t2-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-t2-8.19.0.zip"
             },
             "require": {
-                "t2/admin": "8.18.1",
-                "t2/assets": "8.18.1",
-                "t2/block-library": "8.18.1",
-                "t2/blocks": "8.18.1",
-                "t2/config": "8.18.1",
-                "t2/editor": "8.18.1",
-                "t2/extension-library": "8.18.1",
-                "t2/extensions": "8.18.1",
-                "t2/icons": "8.18.1",
-                "t2/registry": "8.18.1",
-                "t2/utils": "8.18.1"
+                "t2/admin": "8.19.0",
+                "t2/assets": "8.19.0",
+                "t2/block-library": "8.19.0",
+                "t2/blocks": "8.19.0",
+                "t2/config": "8.19.0",
+                "t2/editor": "8.19.0",
+                "t2/extension-library": "8.19.0",
+                "t2/extensions": "8.19.0",
+                "t2/icons": "8.19.0",
+                "t2/registry": "8.19.0",
+                "t2/utils": "8.19.0"
             },
             "type": "wordpress-plugin",
             "license": [
@@ -904,14 +904,14 @@
         },
         {
             "name": "t2/utils",
-            "version": "8.18.1",
+            "version": "8.19.0",
             "dist": {
                 "type": "zip",
-                "url": "https://t2-packages.teft.io/build/t2-utils-8.18.1.zip"
+                "url": "https://t2-packages.teft.io/build/t2-utils-8.19.0.zip"
             },
             "require": {
                 "php": ">=7.2",
-                "t2/registry": "8.18.1"
+                "t2/registry": "8.19.0"
             },
             "type": "package",
             "autoload": {
@@ -958,15 +958,15 @@
         },
         {
             "name": "wpackagist-plugin/spinupwp",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/spinupwp/",
-                "reference": "tags/1.8.0"
+                "reference": "tags/1.9.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/spinupwp.1.8.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/spinupwp.1.9.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -1201,16 +1201,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac"
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
-                "reference": "293975b465e0e709b571cbf0c957c6c0a7b9a2ac",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
                 "shasum": ""
             },
             "require": {
@@ -1267,9 +1267,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-04-24T21:30:46+00:00"
+            "time": "2025-09-19T17:43:28+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,15 +12,15 @@
 			],
 			"devDependencies": {
 				"@csstools/postcss-global-data": "^3.1.0",
-				"@wordpress/env": "^10.30.0",
-				"@wordpress/scripts": "^30.23.0",
+				"@wordpress/env": "^10.32.0",
+				"@wordpress/scripts": "^30.25.0",
 				"autoprefixer": "^10.4.21",
 				"browser-sync": "^3.0.4",
 				"cssnano": "^7.1.1",
-				"dotenv": "^17.2.2",
+				"dotenv": "^17.2.3",
 				"eslint-plugin-prettier": "^5.5.4",
 				"husky": "^9.1.7",
-				"lint-staged": "^16.1.6",
+				"lint-staged": "^16.2.3",
 				"npm-run-all": "^4.1.5",
 				"postcss": "^8.5.6",
 				"postcss-custom-media": "^11.0.6",
@@ -31,7 +31,7 @@
 				"postcss-nesting": "^13.0.2",
 				"postcss-url": "^10.1.3",
 				"prettier": "^3.6.2",
-				"turbo": "^2.5.6"
+				"turbo": "^2.5.8"
 			},
 			"engines": {
 				"node": "20",
@@ -2009,6 +2009,47 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@cacheable/memoize": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@cacheable/memoize/-/memoize-2.0.3.tgz",
+			"integrity": "sha512-hl9wfQgpiydhQEIv7fkjEzTGE+tcosCXLKFDO707wYJ/78FVOlowb36djex5GdbSyeHnG62pomYLMuV/OT8Pbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cacheable/utils": "^2.0.3"
+			}
+		},
+		"node_modules/@cacheable/memory": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.3.tgz",
+			"integrity": "sha512-R3UKy/CKOyb1LZG/VRCTMcpiMDyLH7SH3JrraRdK6kf3GweWCOU3sgvE13W3TiDRbxnDKylzKJvhUAvWl9LQOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@cacheable/memoize": "^2.0.3",
+				"@cacheable/utils": "^2.0.3",
+				"@keyv/bigmap": "^1.0.2",
+				"hookified": "^1.12.1",
+				"keyv": "^5.5.3"
+			}
+		},
+		"node_modules/@cacheable/memory/node_modules/keyv": {
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
+			"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@keyv/serialize": "^1.1.1"
+			}
+		},
+		"node_modules/@cacheable/utils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.0.3.tgz",
+			"integrity": "sha512-m7Rce68cMHlAUjvWBy9Ru1Nmw5gU0SjGGtQDdhpe6E0xnbcvrIY0Epy//JU1VYYBUTzrG9jvgmTauULGKzOkWA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@csstools/cascade-layer-name-parser": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-2.0.5.tgz",
@@ -3263,10 +3304,23 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@keyv/bigmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.2.tgz",
+			"integrity": "sha512-KR03xkEZlAZNF4IxXgVXb+uNIVNvwdh8UwI0cnc7WI6a+aQcDp8GL80qVfeB4E5NpsKJzou5jU0r6yLSSbMOtA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hookified": "^1.12.1"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/@keyv/serialize": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
-			"integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+			"integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4287,14 +4341,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
-			"integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+			"version": "1.55.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+			"integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.55.0"
+				"playwright": "1.55.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -5913,9 +5967,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.30.0.tgz",
-			"integrity": "sha512-DUEAseIg3Xqa4MroaFQEob4TYTGJv0zKRLsDrLHAgQCTtC4PcvUqU0gM7JZjG3zo20G9R5YCBNzx1353qd1t7Q==",
+			"version": "8.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.32.0.tgz",
+			"integrity": "sha512-K6sbRuLpLQWDnIhg0FRWuHOV68BMsrPrNeMNt1TcFDOMCqozI/mnfwCbejfIO7ZPqJtbfucnh1OQ9EkMWPibew==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5925,8 +5979,8 @@
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
 				"@babel/runtime": "7.25.7",
-				"@wordpress/browserslist-config": "^6.30.0",
-				"@wordpress/warning": "^3.30.0",
+				"@wordpress/browserslist-config": "^6.32.0",
+				"@wordpress/warning": "^3.32.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -6115,9 +6169,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.6.0.tgz",
-			"integrity": "sha512-72OqyskL5E8V7trJYt4xlNbOfgAtAFfpwa+8TR+wLwqIYxhFjsWmkZsT3aknE6cyfRAmKZgSUfEZr8zH6Skwyw==",
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.8.0.tgz",
+			"integrity": "sha512-x3LCQ4DuIOg58LyQRZtI6shmNKCk2zuKGwIEMH7h7MMri/Q95ehR6Sub8dKiUL4AHktdlweouJwbHaqrXPkd0Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6126,9 +6180,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.30.0.tgz",
-			"integrity": "sha512-CjirkPIkMf72VQcKmhmQZUJGHHFEt80ITZVgnxEtyswWA6QPRXIwFhQOAElmfhWg2wS6pCncyg6k7DfgYX3bOg==",
+			"version": "6.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.32.0.tgz",
+			"integrity": "sha512-8NemosyPrey1yswd6LH8vX9mcRF6Xmqt2mKUCspnmEX4KvayyezmtJPh2EQo3GfySVHGWePzb0yfMYEqDdsC0Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6137,9 +6191,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.30.0.tgz",
-			"integrity": "sha512-sms4yRJriS8vzlwbYHII/xqI64oSY5ALbfQy6HJBSCfLJCNxVOzC/2fCrhdV9ghd8nK3NMAJKhTCe09oMPCnIw==",
+			"version": "6.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.32.0.tgz",
+			"integrity": "sha512-05XLzLx+cTXgid6/qI6XzBclNvkLIi9F0oLAn4htL1ExIXLfc9yBSNcNkVVP7Tr5pmpMq0NUxfM58jqxxmFfCQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6161,9 +6215,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.30.0.tgz",
-			"integrity": "sha512-KN/q6359nlb+zh/eamQD0gBgi1616Px7v+03+Hz8HqKUPKozUab1ogxr6Ew751LCYGuh204eG7ImYVM6Aqta0Q==",
+			"version": "1.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.32.0.tgz",
+			"integrity": "sha512-w1hE7xDB06SQDfwtbggyU2xTyQ++GyU2wwEc648LL6OYLh7wlDuEzP/7XCrYbxA/GPGFDKCOL3uhU163F2N/Dw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6183,9 +6237,9 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "10.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.30.0.tgz",
-			"integrity": "sha512-tSLv+JExJe5BZpZcExxEtPsIoivxglnes2l7yvxxiaCHwY39LZsgn6lX8QPet4KOoZqE5R/HjH6mXS+lFc3Q/w==",
+			"version": "10.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.32.0.tgz",
+			"integrity": "sha512-GHpcbfh/rUoXd7hwBy84ZBd1uhqQntd9CHrxk5hK/lLM9LULLwrRFC21ZwYwZuNjpdV+DslpsX0N/poe3ybaJQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6211,17 +6265,17 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "22.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.16.0.tgz",
-			"integrity": "sha512-1z3rXq2uanCY0m2D1BgimeNGxZOZy87VPwzKRjaf2aPLw/ezoQckiaVGAKYKhbHLt6HFP2EkdKfuD3pmbTJ57g==",
+			"version": "22.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-22.18.0.tgz",
+			"integrity": "sha512-1w4bhax+vg3xFDXs/z2jNRaCO/kagpK0ZZ6PGWH5Anlp+e9MuzQHMbcU6Xpd/+ZU118z0rJeXDvjb3QgEfvEOg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.30.0",
-				"@wordpress/prettier-config": "^4.30.0",
+				"@wordpress/babel-preset-default": "^8.32.0",
+				"@wordpress/prettier-config": "^4.32.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
@@ -6282,9 +6336,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.30.0.tgz",
-			"integrity": "sha512-Vw7iBqsueb9jCy6RnnjixjLosm+fMi+3iMQDiBB5Pw/yUpr0PUBCR11oQCE/nO3wDl7OOA5Nq3v2qo/wxLBLMg==",
+			"version": "8.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.32.0.tgz",
+			"integrity": "sha512-Sq4Ss0gJNmLzpJ9K/5Nto/FTV5L7ALvmdfA7b8JpmuKh32CETN4uIGDSfqS2a5Pfcg4KepwnL6jF9790uM54QA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6300,13 +6354,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.30.0.tgz",
-			"integrity": "sha512-nxldSo9luQBfjIFF08hcVT1pEVABe213qBxYWCXMCx3+SPsENRF6pU/yoRb0i7nz6yrd/j5oD92EXXnbQoN8eA==",
+			"version": "12.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.32.0.tgz",
+			"integrity": "sha512-Y8X+0KCjUiB1MxxwridiY0Ku3iJVOTJSsutSReu+rM/hS/1azlBMctC0bqUyC0mQyBqPF0SNlpHjYdsAoVEznQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.30.0",
+				"@wordpress/jest-console": "^8.32.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -6319,9 +6373,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.30.0.tgz",
-			"integrity": "sha512-pJ5XMmj2Osk05/TFrCpf6l6VuxWDU837ISKW1bXAmBfpnLTlUuVUl6pTWbIE4gNZqb2faSBQSN3OPeQqt4RNJg==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.32.0.tgz",
+			"integrity": "sha512-X3D9g0m0OIM6FfdHfmyGENOZG53kc+i49WuHnDnC1gZWV5Ai0SD/CNfRcPZOYw7Ld9CScrM3kqXAKG7nd1fGFg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6333,13 +6387,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.30.0.tgz",
-			"integrity": "sha512-3mB+tqN9uIQ6h1SXtQUFowNeCv/Cy6vWsUBhPkgU3hj7LQrGbCAmMWefDAQeYHyG0lQfSrAD6jctZ2wZmNXwsQ==",
+			"version": "5.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.32.0.tgz",
+			"integrity": "sha512-cJGgp8Z3o8dKfUWQZtQ/gNceYwLQET1z7RqkOAaSI5O0lelGit8gqpWeA7qYyZb9K1kWwhz8GGVWUIsQhCo2sQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.6.0",
+				"@wordpress/base-styles": "^6.8.0",
 				"autoprefixer": "^10.4.20"
 			},
 			"engines": {
@@ -6351,9 +6405,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.30.0.tgz",
-			"integrity": "sha512-b0tOy/H0A1ilsjAGUKqMJ3idMQbe1XS7K2ViqG62ZMJRUYBEZ1x3t+ne3Z2fVbyNVhrMqq3eZK9BSEuxr67cSg==",
+			"version": "4.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.32.0.tgz",
+			"integrity": "sha512-fS4Z5hXewajLKxbMQY4rdq3fSpUnwHHfLWqOJHXlu3u4rjqVf0VMJsLsSsSM8tV78rU6x6dWIEugG6CnDygYjA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6365,25 +6419,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "30.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.23.0.tgz",
-			"integrity": "sha512-IVMv4GvSxZQuj/JybHMHA0BbScv2//tELUQSHMe7IHRxvaqzd8WDJgMfnwaqQWOmtw8d4739w7kAEo26kh6zWA==",
+			"version": "30.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-30.25.0.tgz",
+			"integrity": "sha512-sUL6R4aYzdvrg8V7W49RxLsLavv7ZuQ4/6gIb/ZCYZDwhzT4feqdMXyViwmlyaQMIxTMJy93zD+7jFrUGy07Sw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.30.0",
-				"@wordpress/browserslist-config": "^6.30.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.30.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.30.0",
-				"@wordpress/eslint-plugin": "^22.16.0",
-				"@wordpress/jest-preset-default": "^12.30.0",
-				"@wordpress/npm-package-json-lint-config": "^5.30.0",
-				"@wordpress/postcss-plugins-preset": "^5.30.0",
-				"@wordpress/prettier-config": "^4.30.0",
-				"@wordpress/stylelint-config": "^23.22.0",
+				"@wordpress/babel-preset-default": "^8.32.0",
+				"@wordpress/browserslist-config": "^6.32.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.32.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.32.0",
+				"@wordpress/eslint-plugin": "^22.18.0",
+				"@wordpress/jest-preset-default": "^12.32.0",
+				"@wordpress/npm-package-json-lint-config": "^5.32.0",
+				"@wordpress/postcss-plugins-preset": "^5.32.0",
+				"@wordpress/prettier-config": "^4.32.0",
+				"@wordpress/stylelint-config": "^23.24.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -6998,9 +7052,9 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.22.0.tgz",
-			"integrity": "sha512-d1aEVn6jbMFFJh3SqpGKoNsnm0DcYD6TwgzLLlIL11kslyFEn6mfiKJVeVNIgWQe7sBDEtUkE7h4qEOSDbxO8A==",
+			"version": "23.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.24.0.tgz",
+			"integrity": "sha512-qF0zRv/fLK29/jEjQnY0xy1hrP5Cv6ReG10QkVAtSlaBvu07Hu+RWNIVrSznwlrbzzP+2JM61lO2oAeX/3LD+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7018,9 +7072,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.30.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.30.0.tgz",
-			"integrity": "sha512-ZtkpSe3DhtUzIrwf+5slGkJJCxy1xn56fZ6atUaJWRbjsKnIZlTcPgahPUJZ2bugsGS5BlmDEuVI8C4NUdbwvQ==",
+			"version": "3.32.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.32.0.tgz",
+			"integrity": "sha512-6dPNKfJAOXijIMi9k/QdS/IQvHXcl5ErNM10y5dIhhLDuGmsZlQER06VrVmQIVAkbsmL49OfrqkqMOQidp61JA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8338,14 +8392,17 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "1.10.4",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.4.tgz",
-			"integrity": "sha512-Gd7ccIUkZ9TE2odLQVS+PDjIvQCdJKUlLdJRVvZu0aipj07Qfx+XIej7hhDrKGGoIxV5m5fT/kOJNJPQhQneRg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.0.3.tgz",
+			"integrity": "sha512-nZF80J3d8RMrroMSYm1E9pBllVDXWPuECZgEZxH+vusCY4MAXAJVrY0jutcHSgh3xYX3G2EUNnmtWGZVVjWCXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.11.0",
-				"keyv": "^5.5.0"
+				"@cacheable/memoize": "^2.0.3",
+				"@cacheable/memory": "^2.0.3",
+				"@cacheable/utils": "^2.0.3",
+				"hookified": "^1.12.1",
+				"keyv": "^5.5.3"
 			}
 		},
 		"node_modules/cacheable-lookup": {
@@ -8378,13 +8435,13 @@
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
-			"integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
+			"integrity": "sha512-h0Un1ieD+HUrzBH6dJXhod3ifSghk5Hw/2Y4/KHBziPlZecrFyE9YOTPU6eOs0V9pYl8gOs86fkr/KN8lUX39A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@keyv/serialize": "^1.1.0"
+				"@keyv/serialize": "^1.1.1"
 			}
 		},
 		"node_modules/call-bind": {
@@ -8681,9 +8738,9 @@
 			}
 		},
 		"node_modules/chrome-launcher": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
-			"integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
+			"integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8783,17 +8840,17 @@
 			}
 		},
 		"node_modules/cli-truncate": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.0.tgz",
+			"integrity": "sha512-7JDGG+4Zp0CsknDCedl0DYdaeOhc46QNpXi3NLQblkZpXXgA6LncLDUUyvrjSvZeF3VRQa+KiMGomazQrC1V8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"slice-ansi": "^5.0.0",
-				"string-width": "^7.0.0"
+				"slice-ansi": "^7.1.0",
+				"string-width": "^8.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9123,9 +9180,9 @@
 			}
 		},
 		"node_modules/configstore": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.0.0.tgz",
-			"integrity": "sha512-yk7/5PN5im4qwz0WFZW3PXnzHgPu9mX29Y8uZ3aefe2lBPC1FYttWZRcaW9fKkT0pBCJyuQ2HfbmPVaODi9jcQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+			"integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -9138,7 +9195,7 @@
 				"node": ">=18"
 			},
 			"funding": {
-				"url": "https://github.com/yeoman/configstore?sponsor=1"
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/connect": {
@@ -9892,9 +9949,9 @@
 			"license": "MIT"
 		},
 		"node_modules/debug": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10378,9 +10435,9 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.2.2",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
-			"integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+			"version": "17.2.3",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -12768,9 +12825,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.1.tgz",
-			"integrity": "sha512-R1QfovbPsKmosqTnPoRFiJ7CF9MLRgb53ChvMZm+r4p76/+8yKDy17qLL2PKInORy2RkZZekuK0efYgmzTkXyQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
+			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13292,9 +13349,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.0.tgz",
-			"integrity": "sha512-hMr1Y9TCLshScrBbV2QxJ9BROddxZ12MX9KsCtuGGy/3SmmN5H1PllKerrVlSotur9dlE8hmUKAOSa3WDzsZmQ==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.12.1.tgz",
+			"integrity": "sha512-xnKGl+iMIlhrZmGHB729MqlmPoWBznctSQTYCpFKqNsCgimJQmithcW0xSQMMFzYnV2iKUh25alswn6epgxS0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13700,9 +13757,9 @@
 			}
 		},
 		"node_modules/import-in-the-middle": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-			"integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+			"version": "1.14.4",
+			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+			"integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -14090,13 +14147,16 @@
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+			"integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
 			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.3.1"
+			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -15614,13 +15674,13 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.10.8",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.8.tgz",
-			"integrity": "sha512-f02QYEnBDE0p8cteNoPYHHjbDuwyfbe4cCIVlNi8/MRicIxFW4w4CfgU0LNgWEID6s06P+hRJ1qjpBLMhPRCiQ==",
+			"version": "2.10.10",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.10.tgz",
+			"integrity": "sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"debug": "^4.4.1",
+				"debug": "^4.4.3",
 				"extract-zip": "^2.0.1",
 				"progress": "^2.0.3",
 				"proxy-agent": "^6.5.0",
@@ -15664,17 +15724,18 @@
 			"license": "MIT"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.19.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.19.0.tgz",
-			"integrity": "sha512-qsEys4OIb2VGC2tNWKAs4U0mnjkIAxueMOOzk2nEFM9g4Y8QuvYkEMtmwsEdvzNGsUFd7DprOQfABmlN7WBOlg==",
+			"version": "24.23.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.23.0.tgz",
+			"integrity": "sha512-yl25C59gb14sOdIiSnJ08XiPP+O2RjuyZmEG+RjYmCXO7au0jcLf7fRiyii96dXGUBW7Zwei/mVKfxMx/POeFw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.10.8",
-				"chromium-bidi": "8.0.0",
-				"debug": "^4.4.1",
-				"devtools-protocol": "0.0.1495869",
+				"@puppeteer/browsers": "2.10.10",
+				"chromium-bidi": "9.1.0",
+				"debug": "^4.4.3",
+				"devtools-protocol": "0.0.1508733",
 				"typed-query-selector": "^2.12.0",
+				"webdriver-bidi-protocol": "0.3.6",
 				"ws": "^8.18.3"
 			},
 			"engines": {
@@ -15682,9 +15743,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
-			"integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-9.1.0.tgz",
+			"integrity": "sha512-rlUzQ4WzIAWdIbY/viPShhZU2n21CxDUgazXVbw4Hu1MwaeUSEksSeM6DqPgpRjCLXRk702AVRxJxoOz0dw4OA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -15696,9 +15757,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1495869",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
-			"integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
+			"version": "0.0.1508733",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1508733.tgz",
+			"integrity": "sha512-QJ1R5gtck6nDcdM+nlsaJXcelPEI7ZxSMw1ujHpO1c4+9l+Nue5qlebi9xO1Z2MGr92bFOQTW7/rrheh5hHxDg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -15806,19 +15867,16 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "16.1.6",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.6.tgz",
-			"integrity": "sha512-U4kuulU3CKIytlkLlaHcGgKscNfJPNTiDF2avIUGFCv7K95/DCYQ7Ra62ydeRWmgQGg9zJYw2dzdbztwJlqrow==",
+			"version": "16.2.3",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.3.tgz",
+			"integrity": "sha512-1OnJEESB9zZqsp61XHH2fvpS1es3hRCxMplF/AJUDa8Ho8VrscYDIuxGrj3m8KPXbcWZ8fT9XTMUhEQmOVKpKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^5.6.0",
-				"commander": "^14.0.0",
-				"debug": "^4.4.1",
-				"lilconfig": "^3.1.3",
-				"listr2": "^9.0.3",
+				"commander": "^14.0.1",
+				"listr2": "^9.0.4",
 				"micromatch": "^4.0.8",
-				"nano-spawn": "^1.0.2",
+				"nano-spawn": "^1.0.3",
 				"pidtree": "^0.6.0",
 				"string-argv": "^0.3.2",
 				"yaml": "^2.8.1"
@@ -15833,23 +15891,10 @@
 				"url": "https://opencollective.com/lint-staged"
 			}
 		},
-		"node_modules/lint-staged/node_modules/chalk": {
-			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/lint-staged/node_modules/commander": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-			"integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
+			"integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15857,13 +15902,13 @@
 			}
 		},
 		"node_modules/listr2": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.3.tgz",
-			"integrity": "sha512-0aeh5HHHgmq1KRdMMDHfhMWQmIT/m7nRDTlxlFqni2Sp0had9baqsjJRvDGdlvgd6NmPE0nPloOipiQJGFtTHQ==",
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.4.tgz",
+			"integrity": "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cli-truncate": "^4.0.0",
+				"cli-truncate": "^5.0.0",
 				"colorette": "^2.0.20",
 				"eventemitter3": "^5.0.1",
 				"log-update": "^6.1.0",
@@ -15900,12 +15945,37 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/listr2/node_modules/emoji-regex": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+			"integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/listr2/node_modules/eventemitter3": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
 			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/listr2/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/listr2/node_modules/strip-ansi": {
 			"version": "7.1.2",
@@ -16123,9 +16193,9 @@
 			}
 		},
 		"node_modules/log-update/node_modules/ansi-escapes": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
+			"integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16164,37 +16234,29 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/log-update/node_modules/is-fullwidth-code-point": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
-			"integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+		"node_modules/log-update/node_modules/emoji-regex": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
+			"integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/log-update/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-east-asian-width": "^1.3.1"
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
 				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/slice-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
 		"node_modules/log-update/node_modules/strip-ansi": {
@@ -18495,14 +18557,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
-			"integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+			"version": "1.55.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+			"integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.55.0"
+				"playwright-core": "1.55.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -18515,9 +18577,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.55.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
-			"integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+			"version": "1.55.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+			"integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -21845,17 +21907,17 @@
 			}
 		},
 		"node_modules/slice-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+			"integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.0.0",
-				"is-fullwidth-code-point": "^4.0.0"
+				"ansi-styles": "^6.2.1",
+				"is-fullwidth-code-point": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -22422,18 +22484,17 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+			"integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
+				"get-east-asian-width": "^1.3.0",
 				"strip-ansi": "^7.1.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -22484,13 +22545,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
-		},
-		"node_modules/string-width/node_modules/emoji-regex": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
-			"integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/string-width/node_modules/strip-ansi": {
 			"version": "7.1.2",
@@ -23047,15 +23101,15 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.13",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.13.tgz",
-			"integrity": "sha512-gmtS2PaUjSPa4zjObEIn4WWliKyZzYljgxODBfxugpK6q6HU9ClXzgCJ+nlcPKY9Bt090ypTOLIFWkV0jbKFjw==",
+			"version": "6.1.17",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.17.tgz",
+			"integrity": "sha512-Jzse4YoiUJBVYTwz5Bwl4h/2VQM7e2KK3MVAMlXzX9uamIHAH/TXUlRKU1AQGQOryQhN0EsmufiiF40G057YXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^1.10.4",
+				"cacheable": "^2.0.3",
 				"flatted": "^3.3.3",
-				"hookified": "^1.11.0"
+				"hookified": "^1.12.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
@@ -23758,20 +23812,20 @@
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.13.tgz",
-			"integrity": "sha512-Td0LeWLgXJGsikI4mO82fRexgPCEyTcwWiXJERF/GBHX3Dm+HQq/wx4HnYowCbiwQ8d+ENLZc+ktbZw8H+0oEA==",
+			"version": "7.0.16",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+			"integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tldts-icann": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.13.tgz",
-			"integrity": "sha512-hEjcWO0dKLDPZWrhxWNNl7MpJQmQ6An6mj64HTLGd259ZADs8JNXbpzmaLIjwe7q0I35gkDxCJQu703XW5C0Vw==",
+			"version": "7.0.16",
+			"resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.16.tgz",
+			"integrity": "sha512-WS/pPasPs2cx6orcxCcIz01SlG3dwYlgjLAnQt7vLAusTuTLqdI8zmkqbM8TWYEf3Z0o1S4BzM3oSRFPk/6WnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.0.13"
+				"tldts-core": "^7.0.16"
 			}
 		},
 		"node_modules/tmpl": {
@@ -23976,27 +24030,27 @@
 			"license": "0BSD"
 		},
 		"node_modules/turbo": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.6.tgz",
-			"integrity": "sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.8.tgz",
+			"integrity": "sha512-5c9Fdsr9qfpT3hA0EyYSFRZj1dVVsb6KIWubA9JBYZ/9ZEAijgUEae0BBR/Xl/wekt4w65/lYLTFaP3JmwSO8w==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"turbo": "bin/turbo"
 			},
 			"optionalDependencies": {
-				"turbo-darwin-64": "2.5.6",
-				"turbo-darwin-arm64": "2.5.6",
-				"turbo-linux-64": "2.5.6",
-				"turbo-linux-arm64": "2.5.6",
-				"turbo-windows-64": "2.5.6",
-				"turbo-windows-arm64": "2.5.6"
+				"turbo-darwin-64": "2.5.8",
+				"turbo-darwin-arm64": "2.5.8",
+				"turbo-linux-64": "2.5.8",
+				"turbo-linux-arm64": "2.5.8",
+				"turbo-windows-64": "2.5.8",
+				"turbo-windows-arm64": "2.5.8"
 			}
 		},
 		"node_modules/turbo-darwin-64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.6.tgz",
-			"integrity": "sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.8.tgz",
+			"integrity": "sha512-Dh5bCACiHO8rUXZLpKw+m3FiHtAp2CkanSyJre+SInEvEr5kIxjGvCK/8MFX8SFRjQuhjtvpIvYYZJB4AGCxNQ==",
 			"cpu": [
 				"x64"
 			],
@@ -24008,9 +24062,9 @@
 			]
 		},
 		"node_modules/turbo-darwin-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.6.tgz",
-			"integrity": "sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.8.tgz",
+			"integrity": "sha512-f1H/tQC9px7+hmXn6Kx/w8Jd/FneIUnvLlcI/7RGHunxfOkKJKvsoiNzySkoHQ8uq1pJnhJ0xNGTlYM48ZaJOQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -24022,9 +24076,9 @@
 			]
 		},
 		"node_modules/turbo-linux-64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.6.tgz",
-			"integrity": "sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.8.tgz",
+			"integrity": "sha512-hMyvc7w7yadBlZBGl/bnR6O+dJTx3XkTeyTTH4zEjERO6ChEs0SrN8jTFj1lueNXKIHh1SnALmy6VctKMGnWfw==",
 			"cpu": [
 				"x64"
 			],
@@ -24036,9 +24090,9 @@
 			]
 		},
 		"node_modules/turbo-linux-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.6.tgz",
-			"integrity": "sha512-10Tm15bruJEA3m0V7iZcnQBpObGBcOgUcO+sY7/2vk1bweW34LMhkWi8svjV9iDF68+KJDThnYDlYE/bc7/zzQ==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.8.tgz",
+			"integrity": "sha512-LQELGa7bAqV2f+3rTMRPnj5G/OHAe2U+0N9BwsZvfMvHSUbsQ3bBMWdSQaYNicok7wOZcHjz2TkESn1hYK6xIQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -24050,9 +24104,9 @@
 			]
 		},
 		"node_modules/turbo-windows-64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.6.tgz",
-			"integrity": "sha512-FyRsVpgaj76It0ludwZsNN40ytHN+17E4PFJyeliBEbxrGTc5BexlXVpufB7XlAaoaZVxbS6KT8RofLfDRyEPg==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.8.tgz",
+			"integrity": "sha512-3YdcaW34TrN1AWwqgYL9gUqmZsMT4T7g8Y5Azz+uwwEJW+4sgcJkIi9pYFyU4ZBSjBvkfuPZkGgfStir5BBDJQ==",
 			"cpu": [
 				"x64"
 			],
@@ -24064,9 +24118,9 @@
 			]
 		},
 		"node_modules/turbo-windows-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.6.tgz",
-			"integrity": "sha512-j/tWu8cMeQ7HPpKri6jvKtyXg9K1gRyhdK4tKrrchH8GNHscPX/F71zax58yYtLRWTiK04zNzPcUJuoS0+v/+Q==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.8.tgz",
+			"integrity": "sha512-eFC5XzLmgXJfnAK3UMTmVECCwuBcORrWdewoiXBnUm934DY6QN8YowC/srhNnROMpaKaqNeRpoB5FxCww3eteQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -24653,6 +24707,13 @@
 			"version": "4.2.4",
 			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
 			"integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/webdriver-bidi-protocol": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.6.tgz",
+			"integrity": "sha512-mlGndEOA9yK9YAbvtxaPTqdi/kaCWYYfwrZvGzcmkr/3lWM+tQj53BxtpVd6qbC6+E5OnHXgCcAhre6AkXzxjA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -25564,7 +25625,7 @@
 			"name": "@dekode/block-theme",
 			"version": "1.0.0",
 			"devDependencies": {
-				"@wordpress/scripts": "^30.23.0",
+				"@wordpress/scripts": "^30.25.0",
 				"fast-glob": "^3.3.3"
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
 	],
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^3.1.0",
-		"@wordpress/env": "^10.30.0",
-		"@wordpress/scripts": "^30.23.0",
+		"@wordpress/env": "^10.32.0",
+		"@wordpress/scripts": "^30.25.0",
 		"autoprefixer": "^10.4.21",
 		"browser-sync": "^3.0.4",
 		"cssnano": "^7.1.1",
-		"dotenv": "^17.2.2",
+		"dotenv": "^17.2.3",
 		"eslint-plugin-prettier": "^5.5.4",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.1.6",
+		"lint-staged": "^16.2.3",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.5.6",
 		"postcss-custom-media": "^11.0.6",
@@ -32,7 +32,7 @@
 		"postcss-nesting": "^13.0.2",
 		"postcss-url": "^10.1.3",
 		"prettier": "^3.6.2",
-		"turbo": "^2.5.6"
+		"turbo": "^2.5.8"
 	},
 	"scripts": {
 		"create-block": "cd packages/plugins && npx dekodeinteraktiv/create-project-base-block",

--- a/packages/themes/block-theme/package.json
+++ b/packages/themes/block-theme/package.json
@@ -3,7 +3,7 @@
 	"private": true,
 	"version": "1.0.0",
 	"devDependencies": {
-		"@wordpress/scripts": "^30.23.0",
+		"@wordpress/scripts": "^30.25.0",
 		"fast-glob": "^3.3.3"
 	},
 	"scripts": {


### PR DESCRIPTION
Bump WordPress to 6.8.3, T2 packages to 8.19.0, and SpinupWP to 1.9.0 in composer.json. Update related lock files. Also update various JavaScript devDependencies including @wordpress/*, dotenv, lint-staged, turbo, and others in package.json and package-lock.json to their latest versions.