### PR TITLE
Update .prettierignore to include CSS files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,6 @@ dist
 build
 vendor
 wp
-*.css
 *.lock
 *.md
 package-lock.json


### PR DESCRIPTION
## Short introduction
- Remove '*.css' from the Prettier ignore list.
Fixes #597