### PR TITLE
Use CSS for spacing

### DIFF
--- a/packages/themes/block-theme/src/config/_index.css
+++ b/packages/themes/block-theme/src/config/_index.css
@@ -1,0 +1,1 @@
+@import "layout.css";

--- a/packages/themes/block-theme/src/config/layout.css
+++ b/packages/themes/block-theme/src/config/layout.css
@@ -1,0 +1,104 @@
+/**
+ * Configuration – Layout.
+ */
+
+.wp-site-blocks {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
+
+	& * {
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+
+	& > * {
+		margin: 0;
+	}
+
+	& > .content-wrapper {
+		flex: 1;
+	}
+
+	& > .footer-wrapper {
+		margin-top: var(--wp--preset--spacing--80);
+	}
+
+	&:has(.wp-block-post-content > .alignfull:last-child) .footer-wrapper {
+		margin-top: 0;
+	}
+}
+
+.entry-content > .wp-block-group > *,
+.wp-block-post-content > *,
+.wp-block-post-content.is-layout-constrained > * {
+	margin-bottom: 0;
+	margin-top: var(--wp--preset--spacing--80);
+
+	/* Core — Heading */
+	&.wp-block-heading,
+	&:is(h1, h2, h3, h4, h5, h6) {
+		& + * {
+			margin-top: var(--wp--preset--spacing--50);
+
+			&.alignfull {
+				margin-top: var(--wp--preset--spacing--80);
+			}
+		}
+
+		& + p,
+		& + .wp-block-list,
+		& + .wp-block-paragraph {
+			margin-top: var(--wp--preset--spacing--30);
+		}
+	}
+
+	/* Core — Image */
+	&.wp-block-image {
+		&:not(.alignfull) {
+			& + p,
+			& + .wp-block-paragraph {
+				margin-top: var(--wp--preset--spacing--60);
+			}
+
+			& + .wp-block-heading,
+			& + *:is(h1, h2, h3, h4, h5, h6) {
+				margin-top: var(--wp--preset--spacing--60);
+			}
+		}
+	}
+
+	/* Core — List */
+	&.wp-block-list {
+		& + p,
+		& + .wp-block-list,
+		& + .wp-block-paragraph {
+			margin-top: var(--wp--preset--spacing--30);
+		}
+
+		& + .wp-block-heading,
+		& + *:is(h1, h2, h3, h4, h5, h6) {
+			margin-top: var(--wp--preset--spacing--60);
+		}
+	}
+
+	/* Core — Paragraph */
+	&.wp-block-paragraph,
+	&:is(p) {
+		& + p,
+		& + .wp-block-paragraph,
+		& + .wp-block-list {
+			margin-top: var(--wp--preset--spacing--30);
+		}
+
+		& + .wp-block-heading,
+		& + *:is(h1, h2, h3, h4, h5, h6) {
+			margin-top: var(--wp--preset--spacing--60);
+		}
+	}
+}

--- a/packages/themes/block-theme/src/view.css
+++ b/packages/themes/block-theme/src/view.css
@@ -1,3 +1,5 @@
+@import "./config/_index.css";
+
 /* Preferred box-sizing value */
 *,
 *::before,

--- a/packages/themes/block-theme/t2.json
+++ b/packages/themes/block-theme/t2.json
@@ -19,7 +19,6 @@
 		"t2/accessibility-improvements",
 		"t2/allow-svg-uploads",
 		"t2/button-icon",
-		"t2/custom-block-margin",
 		"t2/disable-block-directory",
 		"t2/disable-comments",
 		"t2/disable-custom-css",
@@ -38,8 +37,5 @@
 		"t2/search-block-button-icon",
 		"t2/site-health-qa",
 		"t2/wrap-custom-html-block"
-	],
-	"t2/custom-block-margin": {
-		"version": 3
-	}
+	]
 }

--- a/packages/themes/block-theme/templates/404.html
+++ b/packages/themes/block-theme/templates/404.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-group">
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"content-wrapper"} -->
+<main class="wp-block-group content-wrapper">
 	<!-- wp:heading {"level":1} -->
 	<h1 class="wp-block-heading" id="page-not-found">Page Not Found</h1>
 	<!-- /wp:heading -->

--- a/packages/themes/block-theme/templates/index.html
+++ b/packages/themes/block-theme/templates/index.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-query">
+<!-- wp:query {"tagName":"main","layout":{"type":"constrained"},"className":"content-wrapper"} -->
+<main class="wp-block-query content-wrapper">
 	<!-- wp:query-title {"type":"archive","showPrefix":false,"align":"wide"} /-->
 
 	<!-- wp:post-template {"align":"wide","layout":{"type":"grid","columnCount":3}} -->

--- a/packages/themes/block-theme/templates/search.html
+++ b/packages/themes/block-theme/templates/search.html
@@ -1,7 +1,7 @@
 <!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
 
-<!-- wp:query {"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-query">
+<!-- wp:query {"tagName":"main","layout":{"type":"constrained"},"className":"content-wrapper"} -->
+<main class="wp-block-query content-wrapper">
 	<!-- wp:query-title {"type":"search","align":"wide"} /-->
 	<!-- wp:search /-->
 

--- a/packages/themes/block-theme/templates/singular.html
+++ b/packages/themes/block-theme/templates/singular.html
@@ -1,3 +1,7 @@
 <!-- wp:template-part {"slug":"header","area":"header","tagName":"header","className":"header-wrapper"} /-->
-<!-- wp:post-content {"tagName":"main","align":"full","layout":{"type":"constrained"}} /-->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"},"className":"content-wrapper"} -->
+<main class="wp-block-group content-wrapper">
+	<!-- wp:post-content {"align":"full","layout":{"type":"constrained"}} /-->
+</main>
+<!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer","className":"footer-wrapper"} /-->

--- a/packages/themes/block-theme/theme.json
+++ b/packages/themes/block-theme/theme.json
@@ -274,10 +274,56 @@
 		"spacing": {
 			"blockGap": true,
 			"customSpacingSize": false,
-			"defaultSpacingSizes": true,
+			"defaultSpacingSizes": false,
 			"margin": false,
 			"padding": false,
-			"spacingSizes": []
+			"spacingSizes": [
+				{
+					"name": "4X-Small",
+					"slug": "0",
+					"size": "8px"
+				},
+				{
+					"name": "3X-Small",
+					"slug": "10",
+					"size": "clamp(0.5rem, 0.4391rem + 0.2591vw, 0.75rem)"
+				},
+				{
+					"name": "2X-Small",
+					"slug": "20",
+					"size": "clamp(0.75rem, 0.6891rem + 0.2591vw, 1rem)"
+				},
+				{
+					"name": "X-Small",
+					"slug": "30",
+					"size": "clamp(1rem, 0.8782rem + 0.5181vw, 1.5rem)"
+				},
+				{
+					"name": "Small",
+					"slug": "40",
+					"size": "clamp(1.5rem, 1.3782rem + 0.5181vw, 2rem)"
+				},
+				{
+					"name": "Medium",
+					"slug": "50",
+					"size": "clamp(2rem, 1.7565rem + 1.0363vw, 3rem)"
+				},
+				{
+					"name": "Large",
+					"slug": "60",
+					"size": "clamp(2rem, 1.6347rem + 1.5544vw, 3.5rem)"
+				},
+				{
+					"name": "X-Large",
+					"slug": "70",
+					"size": "clamp(3rem, 2.7565rem + 1.0363vw, 4rem)"
+				},
+				{
+					"name": "2X-Large",
+					"slug": "80",
+					"size": "clamp(3.5rem, 2.5259rem + 4.1451vw, 7.5rem)"
+				}
+			]
 		},
 		"typography": {
 			"customFontSize": false,
@@ -316,26 +362,6 @@
 					"radius": "unset"
 				}
 			},
-			"core/buttons": {
-				"spacing": {
-					"blockGap": "var(--wp--preset--spacing--50)"
-				}
-			},
-			"core/columns": {
-				"spacing": {
-					"blockGap": "var(--wp--preset--spacing--50)"
-				}
-			},
-			"core/group": {
-				"spacing": {
-					"blockGap": "var(--wp--preset--spacing--50)"
-				}
-			},
-			"core/post-template": {
-				"spacing": {
-					"blockGap": "var(--wp--preset--spacing--50)"
-				}
-			},
 			"t2/ingress": {
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--medium)",
@@ -368,12 +394,6 @@
 				}
 			},
 			"caption": {
-				"spacing": {
-					"margin": {
-						"bottom": "0",
-						"top": "0"
-					}
-				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
@@ -403,7 +423,6 @@
 			}
 		},
 		"spacing": {
-			"blockGap": "var(--wp--preset--spacing--80)",
 			"padding": {
 				"left": "1rem",
 				"right": "1rem"


### PR DESCRIPTION
This pull request introduces a major refactor to the block theme’s layout and spacing system. The changes focus on standardizing layout wrappers, centralizing layout-related CSS, and overhauling the spacing configuration for better consistency and maintainability. Additionally, some legacy or redundant features have been removed to streamline the theme.

**Layout and Structure Improvements:**

* Added a new `layout.css` file with comprehensive layout rules and imported it into the main config and view styles, centralizing layout logic for easier maintenance. (`packages/themes/block-theme/src/config/layout.css`, `packages/themes/block-theme/src/config/_index.css`, `packages/themes/block-theme/src/view.css`) [[1]](diffhunk://#diff-69be1d8c11f21e57bbb698f09cb2c60b0f639d948d4bb3adf49bb253ad7aee45R1-R104) [[2]](diffhunk://#diff-207434a9a4f62b626dfc1dbc7463e527c4d21aa6c55b57e013f3cdfa0f201dbcR1) [[3]](diffhunk://#diff-c1aa1637f69e40134d6e29e1d9faa1dc82d9dfdc2ef1c58ce15b2f475d75f5f3R1-R2)
* Updated all main content templates (`404.html`, `index.html`, `search.html`, `singular.html`) to use a standardized `content-wrapper` class, improving layout consistency across pages. (`packages/themes/block-theme/templates/404.html`, `packages/themes/block-theme/templates/index.html`, `packages/themes/block-theme/templates/search.html`, `packages/themes/block-theme/templates/singular.html`) [[1]](diffhunk://#diff-fabbf8c9afe56f3cee97f42d1a97e9e7ad0c5492c1d5978c67b6f96ae1ff0b19L3-R4) [[2]](diffhunk://#diff-e58623782bf37c0382e64908fff4d830e804fdfabd67a0370338c063ab3a0220L3-R4) [[3]](diffhunk://#diff-a7063b22b854047bbd217e371693849d5280ab4d922d0190dd3d8e7370035853L3-R4) [[4]](diffhunk://#diff-f8cb156b4af44e32e012012860b6c10691f9938d8741224f28e042528f8a708bL2-R6)

**Spacing System Overhaul:**

* Disabled default spacing sizes and margin/padding options, then defined a custom set of spacing sizes using `clamp()` for responsive design, providing fine-grained control over spacing throughout the theme. (`packages/themes/block-theme/theme.json`)
* Removed block-specific spacing settings for core blocks (buttons, columns, group, post-template) and the caption element, consolidating spacing logic in the new layout CSS and theme-wide configuration. (`packages/themes/block-theme/theme.json`) [[1]](diffhunk://#diff-b937e077934efd05d3b9601d47536790f204e2a34a2ba423449cc214a75dd2c0L319-L338) [[2]](diffhunk://#diff-b937e077934efd05d3b9601d47536790f204e2a34a2ba423449cc214a75dd2c0L371-L376)
* Removed the global block gap setting from the theme configuration, further centralizing spacing control to the new system. (`packages/themes/block-theme/theme.json`)

**Feature Cleanup:**

* Removed the legacy `custom-block-margin` feature from the theme’s feature registry and configuration, as its functionality is now handled by the new layout and spacing system. (`packages/themes/block-theme/t2.json`) [[1]](diffhunk://#diff-8774f209f73c8ce3b58e560f3da1dc0d48b4b9f8ad9f84afa6e01d22b0479d4cL22) [[2]](diffhunk://#diff-8774f209f73c8ce3b58e560f3da1dc0d48b4b9f8ad9f84afa6e01d22b0479d4cL41-R40)

# Why?

Frontend should be solved with frontend, having a tool created with backend components seems very redundant when CSS is the superior choice when it comes to tweaking on something as fundamental as the layout spacing. The suggested CSS file is clean, easy to understand and makes sure you are 100% in control, no unfortunate margins here and there. The designers have put effort and thought into the UX and how it should visually be presented, if we miss this then the whole flow of readability and the total end result of the site will appear poorly.