### PR TITLE
Fix/apiVersion 3 compatibility fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@
 ### Network Setup
 #WP_ALLOW_MULTISITE=false
 #MULTISITE=false
-#SUBDOMAIN_INSTALL=false # optional: set up multisite with sub directory or sub domain, only used if WP_ALLOW_MULTISITE=true
+#SUBDOMAIN_INSTALL=false # optional: set up multisite with sub directory or sub domain
 
 ### Remote Images
 #DEKODE_PREPEND_IMAGE_URL='https://stage.examplesite.no/' # optional - this requires the remote image must-use package

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -100,7 +100,7 @@
 
 10. Update URLs for multisite to use HTTPS:
     ```bash
-    wp search-replace --url=http://{PROJECT}.site 'http://{PROJECT}.site' 'https://{PROJECT}.site' --recurse-objects --network --skip-columns=guid
+    wp search-replace --url=http://{PROJECT}.site 'http://{PROJECT}.site' 'https://{PROJECT}.site' --recurse-objects --network
     ```
 
 #### Method 2: Using Local Structure (Symlink Method)

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -100,7 +100,7 @@
 
 10. Update URLs for multisite to use HTTPS:
     ```bash
-    wp search-replace --url=http://{PROJECT}.site 'http://{PROJECT}.site' 'https://{PROJECT}.site' --recurse-objects --network
+    wp search-replace --url=http://{PROJECT}.site 'http://{PROJECT}.site' 'https://{PROJECT}.site' --recurse-objects --network --skip-columns=guid
     ```
 
 #### Method 2: Using Local Structure (Symlink Method)

--- a/packages/themes/block-theme/includes/setup-theme.php
+++ b/packages/themes/block-theme/includes/setup-theme.php
@@ -13,9 +13,10 @@ defined( 'ABSPATH' ) || exit;
 
 // Hooks.
 \add_action( 'after_setup_theme', __NAMESPACE__ . '\\do_after_setup_theme' );
-\add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\do_enqueue_assets' );
+
+// Enqueue the theme assets.
+\add_action( 'enqueue_block_assets', __NAMESPACE__ . '\\do_enqueue_block_assets' );
 \add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\do_enqueue_block_editor_assets' );
-\add_filter( 't2/extension/enqueue_theme_block_styles/deps', __NAMESPACE__ . '\\do_override_t2_enqueue_theme_block_styles_deps', 65 );
 
 /**
  * Setup navigation menus and theme supports.
@@ -31,78 +32,89 @@ function do_after_setup_theme(): void {
 }
 
 /**
- * Enqueue frontend scripts and styles.
+ * Enqueue the theme assets.
  *
+ * @param  bool $for_editor Aim to load the editor assets or not.
  * @return void
  */
-function do_enqueue_assets(): void {
+function load_theme_assets( bool $for_editor = false ): void {
 
-	// Bundled stylesheet.
-	if ( \file_exists( \get_template_directory() . '/build/view.css' ) ) {
-		$assets_version = \filemtime( \get_template_directory() . '/build/view.css' );
+	// Aim to make things more readable and predictable below in the code.
+	$dir = \trailingslashit( \get_template_directory() ) . 'build/';
+	$url = \trailingslashit( \get_template_directory_uri() ) . 'build/';
 
-		$deps = [];
+	if ( empty( $for_editor ) ) {
+		$handle = 'block-theme';
+		$assets = \file_exists( $dir . 'view.asset.php' ) ? require $dir . 'view.asset.php' : [];
 
-		/* phpcs:disable
-		// Optionally set all WooCommerce styling as dependency.
-		if ( \class_exists( 'WooCommerce' ) ) {
-			// Optionally incluce Woo styling if plugin is active.
-			$deps[] = 'woocommerce-blocktheme';
-			$deps[] = 'woocommerce-general';
-			$deps[] = 'woocommerce-layout';
+		// Bundled stylesheet.
+		if ( \file_exists( $dir . 'view.css' ) && ! \wp_style_is( $handle ) ) {
+			$ver = $assets['version'] ?? \filemtime( $dir . 'view.css' );
+			\wp_enqueue_style( $handle, $url . 'view.css', [], $ver );
 		}
-		phpcs:enable
-		*/
 
-		\wp_enqueue_style( 'block-theme', \get_template_directory_uri() . '/build/view.css', $deps, $assets_version );
-	}
+		// Bundled scripts.
+		$build_file = $dir . 'view.js';
+		if ( \file_exists( $build_file ) && ! \wp_script_is( $handle ) ) {
+			$dep = $assets['dependencies'] ?? [];
+			$ver = $assets['version'] ?? \filemtime( $dir . 'view.js' );
+			\wp_enqueue_script( $handle, $url . 'view.js', $dep, $ver, true );
+		}
+	} else {
+		$handle = 'block-theme-editor';
+		$assets = \file_exists( $dir . 'editor.asset.php' ) ? require $dir . 'editor.asset.php' : [];
 
-	// Bundled scripts.
-	$build_file  = \get_template_directory() . '/build/view.js';
-	$assets_file = \get_template_directory() . '/build/view.asset.php';
+		// Bundled stylesheet.
+		if ( \file_exists( $dir . 'editor.css' ) && ! \wp_style_is( $handle ) ) {
+			$ver = $assets['version'] ?? \filemtime( $dir . 'editor.css' );
+			\wp_enqueue_style( $handle, $url . 'editor.css', [ 'global-styles-css-custom-properties' ], $ver );
+		}
 
-	if ( \file_exists( $build_file ) && \file_exists( $assets_file ) ) {
-		$assets = require $assets_file;
-		\wp_enqueue_script( 'block-theme', \get_template_directory_uri() . '/build/view.js', $assets['dependencies'], $assets['version'], true );
+		// Bundled scripts.
+		$build_file = $dir . 'editor.js';
+		if ( \file_exists( $build_file ) && ! \wp_script_is( $handle ) ) {
+			$dep = $assets['dependencies'] ?? [];
+			$ver = $assets['version'] ?? \filemtime( $dir . 'editor.js' );
+			\wp_enqueue_script( $handle, $url . 'editor.js', $dep, $ver, true );
+			\wp_set_script_translations( $handle, 'block-theme', \get_template_directory() . '/languages' );
+		}
 	}
 }
 
 /**
- * Enqueue editor style for the WordPress editor.
+ * Enqueue the theme scripts and styles in the WordPress editor and iframe.
+ * Both view and editor assets should be passed.
+ *
+ * @return void
+ */
+function do_enqueue_block_assets(): void {
+	load_theme_assets();
+
+	// Avoid running on normal front-end requests; only load in editor or editor iframe.
+	if ( ! \is_admin() && ( ! \function_exists( '\is_block_editor' ) || ! \is_block_editor() ) ) {
+		// No need to continue.
+		return;
+	}
+
+	load_theme_assets( true );
+}
+
+/**
+ * Enqueue the theme scripts and styles in the WordPress editor.
+ * This is primarily a compatibility hook for editor contexts where
+ * apiVersion 3 is not enabled for all components or the editor is not
+ * rendered in an iframe. View assets are enqueued via
+ * {@see do_enqueue_block_assets()}, while this function ensures the
+ * corresponding editor assets are available.
  *
  * @return void
  */
 function do_enqueue_block_editor_assets(): void {
-	if ( ! is_admin() ) {
+	// Avoid running on normal front-end requests; only load in editor or editor iframe.
+	if ( ! \is_admin() && ( ! \function_exists( '\is_block_editor' ) || ! \is_block_editor() ) ) {
+		// No need to continue.
 		return;
 	}
 
-	// Bundled stylesheet.
-	if ( \file_exists( \get_template_directory() . '/build/editor.css' ) ) {
-		$assets_version = \filemtime( \get_template_directory() . '/build/editor.css' );
-		\wp_enqueue_style( 'block-theme', \get_template_directory_uri() . '/build/editor.css', [ 'global-styles-css-custom-properties' ], $assets_version );
-	}
-
-	// Bundled scripts.
-	$build_file  = \get_template_directory() . '/build/editor.js';
-	$assets_file = \get_template_directory() . '/build/editor.asset.php';
-
-	if ( \file_exists( $build_file ) && \file_exists( $assets_file ) ) {
-		$assets = require $assets_file;
-		\wp_enqueue_script( 'block-theme', \get_template_directory_uri() . '/build/editor.js', $assets['dependencies'], $assets['version'], true );
-
-		\wp_set_script_translations( 'block-theme', 'block-theme', \get_template_directory() . '/languages' );
-		\wp_enqueue_script( 'block-theme' );
-	}
-}
-
-/**
- * Set theme style as depenency for all block styles to ensure correct loading order.
- *
- * @param array $deps Dependencies.
- * @return array
- */
-function do_override_t2_enqueue_theme_block_styles_deps( array $deps ): array {
-	$deps[] = 'block-theme';
-	return $deps;
+	load_theme_assets( true );
 }

--- a/packages/themes/block-theme/src/block.json
+++ b/packages/themes/block-theme/src/block.json
@@ -3,6 +3,5 @@
 	"apiVersion": 3,
 	"name": "project-base/block-theme",
 	"editorScript": "file:./editor.js",
-	"editorStyle": "file:./editor.css",
 	"viewScript": "file:./view.js"
 }

--- a/packages/themes/block-theme/src/block.json
+++ b/packages/themes/block-theme/src/block.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
-	"editorScript": "file:editor.js",
-	"viewScript": "file:view.js"
+	"name": "project-base/block-theme",
+	"editorScript": "file:./editor.js",
+	"editorStyle": "file:./editor.css",
+	"style": "file:./view.css",
+	"viewScript": "file:./view.js"
 }

--- a/packages/themes/block-theme/src/block.json
+++ b/packages/themes/block-theme/src/block.json
@@ -4,6 +4,5 @@
 	"name": "project-base/block-theme",
 	"editorScript": "file:./editor.js",
 	"editorStyle": "file:./editor.css",
-	"style": "file:./view.css",
 	"viewScript": "file:./view.js"
 }


### PR DESCRIPTION
## Short introduction
This PR aims to improve WordPress apiVersion: 3 compatibility for the block theme by updating block metadata and adjusting how theme assets are enqueued across frontend/editor contexts, plus a couple of setup/documentation tweaks.

Changes:

Updated src/block.json to include a block name and explicit editor/view style/script entries using file:./... paths.
Refactored theme asset enqueuing to use enqueue_block_assets / enqueue_block_editor_assets and a shared load_theme_assets() helper.
Adjusted multisite URL update instructions and clarified an .env.example comment.

## Description
- Fixes the issues with the block styles only loaded in the window, not in the iframe, and the conflict from using the same handle for editor and view assets (more iterations and details here https://github.com/DekodeInteraktiv/codex/pull/154) - some conflicts also from the t2/extensions using after the theme setup hook instead of proper enqueue hooks https://github.com/DekodeInteraktiv/T2/blob/610b6ca2d0c2cb87a87fe5d569f7248d7a800243/packages/extension-library/src/enqueue-theme-block-styles/extension.php#L83
