### PR TITLE
Add new Git worktrees helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ debug.log
 wp-debug.log
 .turbo
 .wp-env.override.json
+
+# Git worktrees (parallel Copilot agents — see WORKTREES.md)
+/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,5 @@ wp-debug.log
 .turbo
 .wp-env.override.json
 
-# Git worktrees (parallel Copilot agents — see WORKTREES.md)
+# Git worktrees
 /worktrees/

--- a/tools/local/new-worktree.sh
+++ b/tools/local/new-worktree.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Creates a sibling worktree, copies .env, installs dependencies.
+# Creates a worktree under ./worktrees/, copies .env, installs dependencies.
+# The worktrees/ directory is gitignored.
 # Usage: tools/local/new-worktree.sh <branch-name> [base-branch]
 
 BRANCH="${1:-}"
@@ -13,9 +14,8 @@ if [ -z "$BRANCH" ]; then
 fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-REPO_NAME="$(basename "$REPO_ROOT")"
 SLUG="$(printf '%s' "$BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
-WORKTREES_DIR="$(dirname "$REPO_ROOT")/${REPO_NAME}.worktrees"
+WORKTREES_DIR="${REPO_ROOT}/worktrees"
 TARGET="${WORKTREES_DIR}/${SLUG}"
 
 if [ -e "$TARGET" ]; then

--- a/tools/local/new-worktree.sh
+++ b/tools/local/new-worktree.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates a sibling worktree, copies .env, installs dependencies.
+# Usage: tools/local/new-worktree.sh <branch-name> [base-branch]
+
+BRANCH="${1:-}"
+BASE="${2:-main}"
+
+if [ -z "$BRANCH" ]; then
+  echo "usage: $0 <branch-name> [base-branch]" >&2
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REPO_NAME="$(basename "$REPO_ROOT")"
+SLUG="$(printf '%s' "$BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]')"
+WORKTREES_DIR="$(dirname "$REPO_ROOT")/${REPO_NAME}.worktrees"
+TARGET="${WORKTREES_DIR}/${SLUG}"
+
+if [ -e "$TARGET" ]; then
+  echo "error: $TARGET already exists" >&2
+  exit 1
+fi
+
+mkdir -p "$WORKTREES_DIR"
+
+git -C "$REPO_ROOT" fetch origin --quiet || true
+
+if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git -C "$REPO_ROOT" worktree add "$TARGET" "$BRANCH"
+elif git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  git -C "$REPO_ROOT" worktree add --track -b "$BRANCH" "$TARGET" "origin/$BRANCH"
+else
+  git -C "$REPO_ROOT" worktree add -b "$BRANCH" "$TARGET" "$BASE"
+fi
+
+if [ -f "$REPO_ROOT/.env" ]; then
+  cp "$REPO_ROOT/.env" "$TARGET/.env"
+  echo "copied .env"
+else
+  echo "warning: $REPO_ROOT/.env not found — copy manually before running scripts"
+fi
+
+cd "$TARGET"
+echo "running composer install..."
+composer install
+echo "running npm ci..."
+npm ci
+
+echo
+echo "worktree ready: $TARGET"
+echo "open in your editor, e.g.: code \"$TARGET\""


### PR DESCRIPTION
Adds a script `/tools/local/new-worktree.sh` which can be run locally to create git worktrees and set them up.

It supports a Confluence guide (still a WIP) to make it easier for developers to have multiple agents working on the same codebase.

Needs discussion on the directory structure (where worktrees get created). Currently that is inside the existing repo in the `./worktrees/` directory to keep the existing local structure clean. It could be outside the existing projects though.