### PR TITLE
FEATURE: gitignore envrc file that is automatically added by local in some setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ public/content/languages
 
 # Local
 sql/
+.envrc
 
 # Other
 debug.log


### PR DESCRIPTION
## Short introduction
Remove the .envrc file that might get generated by local if you are using the setup where you switch the "app" folder with your own project.

## Description
Updating local to 10.1.1 will now add an extra file in your app folder called .envrc, it looks nice as if you are downloading [direnv](https://community.localwp.com/t/using-direnv-with-local/52246), you can use site-shell without clicking the site-shell in local.
But this will add the extra file to the repo which is only for you and should not be tracked in git.

https://localwp.com/releases/10.1.1

## Steps to test / reproduce
Update local
Start a site where project base is the renamed to the app folder

## Checklist
- [x] I have written unit tests where applicable
- [x] My code follows the Dekode coding standards
- [x] I've tested my changes with keyboard and screen readers
- [x] My code follows the accessibility standards
- [x] My code is properly documented

- [x] I've declared any PII (Personally Identifiable Information) for anonymization