### PR TITLE
Fix documentation typos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 ##
 # Default configuration options for the environment.
 #
-# All of these options can be overriden by setting them as environment variables before starting
+# All of these options can be overridden by setting them as environment variables before starting
 # the environment. You will need to restart your environment when changing any of these.
 ##
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -227,7 +227,7 @@ You can modify `browsersync.config.js` to change watched files or other BrowserS
 Project Base uses [wp-scripts](https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts) out of the box for building front-end/view and editor assets. wp-script will scan all `block.json` files in the `src/` folder to find available entries. This means that if you have a `src` folder with a `view.js` and a `editor.js`, you also need to add a `block.json` file at the same location. Have a look in the `block-theme` theme for example or read up on [wp-script auto discovery for Webpack entry points](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/utils/config.js#L198). For a more advanced setup, you can always customize builds by adding your own `webpack.config.js`.
 
 ### A quick overview of wp-scripts auto discovery:
-1. Supply entry points manully to the CLI, e.g. `wp-scripts build src/view src/editor src/admin src/some-other-entry`. This will bypass 2 and 3.
+1. Supply entry points manually to the CLI, e.g. `wp-scripts build src/view src/editor src/admin src/some-other-entry`. This will bypass 2 and 3.
 2. Scan `src` folder for all `block.json` files. (Our default setup). This will support both theme/plugin assets (view/editor) and possible blocks inside the `src/` folder.
 3. Fallback to `src/index.*` file. This will only look for a `src/index.js` file.
 
@@ -247,7 +247,7 @@ Project Base uses [wp-scripts](https://github.com/WordPress/gutenberg/tree/trunk
 
    *Note: Use [block-base](https://github.com/DekodeInteraktiv/block-base) for Gutenberg blocks.*
 
-   *Note: A version should always be supplied. This ensures that package versions do not change between branches, leading to unneccesary merge conflicts.*
+   *Note: A version should always be supplied. This ensures that package versions do not change between branches, leading to unnecessary merge conflicts.*
 
 3. **Add a `package.json` File** (for frontend dependencies or custom React components):
    ```json

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add a link to any relevant documentation, and specify which version of an API we
 Add some words about how the third-party server authenticates incoming requests and add any API-keys necessary.
 
 **Any terminal commands that could be useful**
-Any custom made wp-cli commands which communicate with the third party, should be documented here. Also a link to any commands included in plugins which comunicate with the third-party, should be included.
+Any custom made wp-cli commands which communicate with the third party, should be documented here. Also a link to any commands included in plugins which communicate with the third-party, should be included.
 
 ## Cronjobs
 List all non-standard cronjobs on the site and say a few words about the purpose of each of them.

--- a/documentation/build-workflow.md
+++ b/documentation/build-workflow.md
@@ -20,7 +20,7 @@ The Project Base `package.json` root configuration is already prepared to build 
 ```
 Note: This will be part of the scaffolding when using any of the [create block routines](create-block.md).
 
-For project development, run `npm run start` from the project root, as before. This task goes through all the packages that have the start script and run them in paralel.
+For project development, run `npm run start` from the project root, as before. This task goes through all the packages that have the start script and run them in parallel.
 
 ## Different build architectures
 The official `@wordpress/scripts` package supports several entry points configuration to build the packages' assets:
@@ -54,4 +54,3 @@ To learn more about how to extend the default configuration, please refer to the
 ## Browsersync
 
 To learn more about how to enable browsersync, please refer to the [browsersync documentation](browsersync.md).
-

--- a/documentation/deployments.md
+++ b/documentation/deployments.md
@@ -10,7 +10,7 @@ The various deployment steps rely on various secrets by default (these can be mo
 
 ## Production
 
-Code is built, and pushed to production whenever a new release is published. By tieing the deployment to a release, we can ensure that the code is tested in a stage or development environment first, and that no code is accidentally put live by a commit or merge to the wrong branch.
+Code is built, and pushed to production whenever a new release is published. By tying the deployment to a release, we can ensure that the code is tested in a stage or development environment first, and that no code is accidentally put live by a commit or merge to the wrong branch.
 
 It is also possible to run the workflow named `Manually deploy to production` to push a self-determined release tag, commit reference, or branch to production. For example if a hotfix is needed, or a rapid rollback.
 
@@ -29,7 +29,7 @@ The production deployment relies on the following secrets existing:
 
 Code is built, and pushed to stage servers when new code is pushed to the `stage` branch.
 
-Code pushed ot the `stage` branch should be tested as part of the Pull Request routine, as the code will be deployed to the stage servers as soon as it is merged.
+Code pushed to the `stage` branch should be tested as part of the Pull Request routine, as the code will be deployed to the stage servers as soon as it is merged.
 
 It is also possible to run the workflow named `Manually deploy to stage` to push a self-determined release tag, commit reference, or branch to production. This is useful for testing a brand new feature quickly, where the feature branch can be deployed, but should be agreed upon with other team members to avoid new merges overwriting your deployment during such testing.
 


### PR DESCRIPTION
- Correct seven spelling errors in project documentation and the example environment configuration.
- Leave the valid Latin word `ridiculus` unchanged in the block theme placeholder text.

made with https://github.com/crate-ci/typos

## Impact

Documentation-only changes; there is no runtime behavior change.

This for you @PeterBooker